### PR TITLE
Enable Travis CI builds for the iOS version of AffdexMe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: objective-c
+
+osx_image: xcode7
+
+xcode_project: apps/AffdexMe/AffdexMe.xcodeproj
+
+xcode_scheme: AffdexMe
+
+xcode_sdk: iphonesimulator9.0
+
+notifications:
+    email: false
+
+before_install:
+  # Download the latest iOS SDK
+  - wget http://affdex-sdk-dist.s3-website-us-east-1.amazonaws.com/ios/download_sdk.html
+  # Decompress the download
+  - tar xvf download_sdk.html
+  # Copy the Affdex.framework directory into the frameworks directory
+  - cp -R affdex-sdk/Framework_Universal/Affdex.framework frameworks/
+  # Add empty license file so that the project builds
+  - touch apps/AffdexMe/sdk.license

--- a/apps/AffdexMe/AffdexMe.xcodeproj/xcshareddata/xcschemes/AffdexMe.xcscheme
+++ b/apps/AffdexMe/AffdexMe.xcodeproj/xcshareddata/xcschemes/AffdexMe.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65920A6E16D73F8700D89A4B"
+               BuildableName = "AffdexMe.app"
+               BlueprintName = "AffdexMe"
+               ReferencedContainer = "container:AffdexMe.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65920A6E16D73F8700D89A4B"
+            BuildableName = "AffdexMe.app"
+            BlueprintName = "AffdexMe"
+            ReferencedContainer = "container:AffdexMe.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65920A6E16D73F8700D89A4B"
+            BuildableName = "AffdexMe.app"
+            BlueprintName = "AffdexMe"
+            ReferencedContainer = "container:AffdexMe.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65920A6E16D73F8700D89A4B"
+            BuildableName = "AffdexMe.app"
+            BlueprintName = "AffdexMe"
+            ReferencedContainer = "container:AffdexMe.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
This should help with pull requests and give users a starting place for continuous integration with their apps.

I had to add a shared scheme to make this work because xctool, like xcodebuild, isn't able to automatically create schemes.  They suggested sharing a scheme and checking it into source control.

For example output see here:
https://travis-ci.org/j4y/ios-sdk-samples