### PR TITLE
[SDK-1160] Fix Affectiva logo size in Emoji launch screen

### DIFF
--- a/apps/Emoji/LaunchScreen.storyboard
+++ b/apps/Emoji/LaunchScreen.storyboard
@@ -39,13 +39,13 @@
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Affectiva_Logo_Clear_Background.png" translatesAutoresizingMaskIntoConstraints="NO" id="stv-qF-vlN">
                                 <rect key="frame" x="113" y="579.5" width="150" height="28.5"/>
                                 <constraints>
+                                    <constraint firstAttribute="width" constant="150" id="iyU-Zp-Osz"/>
                                     <constraint firstAttribute="width" secondItem="stv-qF-vlN" secondAttribute="height" multiplier="1161:219" id="nN9-zb-xvf"/>
                                 </constraints>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="stv-qF-vlN" firstAttribute="width" secondItem="hQQ-gX-tip" secondAttribute="width" multiplier="0.4" id="72n-CR-WPi"/>
                             <constraint firstItem="eO8-5S-dfa" firstAttribute="top" secondItem="OQr-n7-zI6" secondAttribute="bottom" constant="20" id="8Jh-Gn-R5F"/>
                             <constraint firstItem="OQr-n7-zI6" firstAttribute="leading" secondItem="hQQ-gX-tip" secondAttribute="leadingMargin" constant="20" id="BiK-bB-Jhd"/>
                             <constraint firstAttribute="trailingMargin" secondItem="zSk-d3-eqj" secondAttribute="trailing" constant="20" id="KYq-2E-eO6"/>


### PR DESCRIPTION
In the Emoji launch screen, set the Affectiva logo size to a fixed value so it doesn't scale up and down based on the selected device.